### PR TITLE
Fix cache file management in PersistentData.

### DIFF
--- a/sources/model/Cache/Cache.swift
+++ b/sources/model/Cache/Cache.swift
@@ -41,8 +41,12 @@ struct DataCache {
         cache.removeAllObjects()
     }
 }
+
+fileprivate let fileCacheKey = "file_cache"
+
 struct PersistentData {
     private let filemanager = FileManager()
+    
     let documentsUrl =  FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first! as URL
     
     subscript(_ key: URL) -> Data? {
@@ -51,41 +55,40 @@ struct PersistentData {
         }
         set {
             let path = documentsUrl.appendingPathComponent(key.lastPathComponent)
-            DispatchQueue.global().async{
+            DispatchQueue.main.async {
                 do {
                     let userDefaults = UserDefaults.standard
-                    var array = userDefaults.array(forKey: "file_cache")  ?? [URL]()
-
+                    var set = Set(userDefaults.stringArray(forKey: fileCacheKey) ?? [String]())
+                    
                     if newValue == nil {
                         try FileManager.default.removeItem(at: path)
-                        
-                        if let idx = array.firstIndex(where: {($0 as? URL) == key}){
-                            array.remove(at: idx)
-                        }
-                        
-                        
+                        set.remove(key.absoluteString)
                     } else {
                         try newValue?.write(to: path)
-                        array.append(key)
+                        set.insert(key.absoluteString)
                     }
-                    userDefaults.set(key, forKey: "file_cache")
-                    userDefaults.synchronize()
                     
+                    userDefaults.set(Array(set), forKey: fileCacheKey)
+                    userDefaults.synchronize()
                 } catch {
                     logerror(error)
                 }
-                
             }
         }
     }
     
     func free(){
-        let array = UserDefaults.standard.array(forKey: "file_cache") as? [URL]  ?? [URL]()
-        for item in array {
-           let path = documentsUrl.appendingPathComponent(item.lastPathComponent)
+        let userDefaults = UserDefaults.standard
+        
+        let keys = Set(userDefaults.stringArray(forKey: fileCacheKey) ?? [String]())
+        for item in keys {
+            guard let key = URL(string: item) else { continue }
+            let path = documentsUrl.appendingPathComponent(key.lastPathComponent)
             
             try? FileManager.default.removeItem(at: path)
         }
         
+        userDefaults.removeObject(forKey: fileCacheKey)
+        userDefaults.synchronize()
     }
 }


### PR DESCRIPTION
While learning how your code persists data, I discovered a problem with the management of the keys used to identify the cached files. They weren't being stored in UserDefaults correctly. The net effect was that the management code didn't know which files had been cached, so could not delete them in `free()`. I believe this PR addresses the issues.

**What I did:**
- The access to UserDefaults is now serialized, as the array of keys is used by multiple operations in the queue.
- I changed the array to a set, as there can only be one instance of each key.
- UserDefaults doesn't like URLs, so I stored strings (absoluteString).
- The code now removes all of the keys in the set (actually removes the set itself) from UserDefaults when the cache is "freed".

** Testing**
- I tried the new code in a new instance of the app. It worked
- I tried the new code in an existing instance of the app with the incorrectly-stored keys in UserDefaults. Those keys are read as an empty set, but are stored immediately, which corrects UserDefaults.